### PR TITLE
prefix/: fix paths and add emerge defaults to make.conf, link to host group/passwd

### DIFF
--- a/prefix/final/usr/local/microsoft/etc/group
+++ b/prefix/final/usr/local/microsoft/etc/group
@@ -1,0 +1,1 @@
+/etc/group

--- a/prefix/final/usr/local/microsoft/etc/passwd
+++ b/prefix/final/usr/local/microsoft/etc/passwd
@@ -1,0 +1,1 @@
+/etc/passwd

--- a/prefix/final/usr/local/microsoft/etc/portage/make.conf
+++ b/prefix/final/usr/local/microsoft/etc/portage/make.conf
@@ -1,7 +1,7 @@
 # Created by update_chroot
 DISTDIR="/mnt/host/source/.cache/distfiles"
-PKGDIR="/var/lib/portage/pkgs"
-PORT_LOGDIR="/var/log/portage"
+PKGDIR="/usr/local/microsoft/var/lib/portage/pkgs"
+PORT_LOGDIR="/usr/local/microsoft/var/log/portage"
 PORTAGE_BINHOST=" "
 PORTAGE_USERNAME="sdk"
 MAKEOPTS="--jobs=4"

--- a/prefix/final/usr/local/microsoft/etc/portage/make.conf
+++ b/prefix/final/usr/local/microsoft/etc/portage/make.conf
@@ -7,6 +7,7 @@ PORTAGE_USERNAME="sdk"
 MAKEOPTS="--jobs=4"
 CHOST="x86_64-cros-linux-gnu"
 ACCEPT_KEYWORDS="amd64 -~amd64"
+EMERGE_DEFAULT_OPTS="--root-deps=rdeps --usepkgonly"
 
 USE="
 -desktop

--- a/prefix/staging/usr/local/microsoft/etc/group
+++ b/prefix/staging/usr/local/microsoft/etc/group
@@ -1,0 +1,1 @@
+/etc/group

--- a/prefix/staging/usr/local/microsoft/etc/passwd
+++ b/prefix/staging/usr/local/microsoft/etc/passwd
@@ -1,0 +1,1 @@
+/etc/passwd

--- a/prefix/staging/usr/local/microsoft/etc/portage/make.conf
+++ b/prefix/staging/usr/local/microsoft/etc/portage/make.conf
@@ -1,7 +1,7 @@
 # Created by update_chroot
 DISTDIR="/mnt/host/source/.cache/distfiles"
-PKGDIR="/var/lib/portage/pkgs"
-PORT_LOGDIR="/var/log/portage"
+PKGDIR="/usr/local/microsoft/var/lib/portage/pkgs"
+PORT_LOGDIR="/usr/local/microsoft/var/log/portage"
 PORTAGE_BINHOST=" "
 PORTAGE_USERNAME="sdk"
 MAKEOPTS="--jobs=4"

--- a/prefix/staging/usr/local/microsoft/etc/portage/make.conf
+++ b/prefix/staging/usr/local/microsoft/etc/portage/make.conf
@@ -7,6 +7,7 @@ PORTAGE_USERNAME="sdk"
 MAKEOPTS="--jobs=4"
 CHOST="x86_64-cros-linux-gnu"
 ACCEPT_KEYWORDS="amd64 -~amd64"
+EMERGE_DEFAULT_OPTS="--buildpkg"
 
 USE="
 -desktop


### PR DESCRIPTION
This change updates PKGDIR and PORT_LOGDIR in the prefix's make.conf (both staging and final) to /usr/local/microsoft/var/lib/portage/pkgs and /usr/local/microsoft/var/log/portage, respectively.

This resolves an issue where emerge in the prefix was interfering with the core SDK's emerge (overwriting packages etc.).

It  introduces softlinks in staging/ and final/ etc directories to the root passwd and group files. This ensures that PORTAGE_USERNAME and PORTAGE_GRPNAME defined in the prefix' make.conf files can use users from the host system.

Also, sensible EMERGE_DEFAULT options are added to staging and final make.conf: staging will always build packages, and final will always install rdeps, and only use binpkgs by default.